### PR TITLE
fixed error via massive

### DIFF
--- a/mod0keecrack.c
+++ b/mod0keecrack.c
@@ -390,15 +390,15 @@ int main(int ac, char** av)
   kdbx_header_read(kdbx_fd, &kdbx_db.fileheader);
   kdbx_header_dump(kdbx_db.fileheader);
 
-  kdbx_headerentries_read(kdbx_fd, &kdbx_db.kdbxheader);
-  kdbx_headerentries_dump(&kdbx_db.kdbxheader);
+  kdbx_headerentries_read(kdbx_fd, kdbx_db.kdbxheader);
+  kdbx_headerentries_dump(kdbx_db.kdbxheader);
 
   kdbx_payload_read(kdbx_fd, &kdbx_db.payload);
   kdbx_payload_dump(kdbx_db.payload);
 
   kdbx_payload_crack(&kdbx_db, wordlist_fd);
 
-  kdbx_headerentries_free(&kdbx_db.kdbxheader);
+  kdbx_headerentries_free(kdbx_db.kdbxheader);
   fclose(kdbx_fd);
   exit(0);
 }

--- a/mod0keecrack.h
+++ b/mod0keecrack.h
@@ -91,7 +91,7 @@ typedef struct _m0kdbx_data {
 
 typedef struct _m0_kdbx_database {
   m0_kdbx_header_t        fileheader;
-  m0_kdbx_header_entry_t  kdbxheader;
+  m0_kdbx_header_entry_t  kdbxheader[10];
   m0_kdbx_payload_t       payload;
 } m0_kdbx_database_t;
 


### PR DESCRIPTION
Argument function seems to be massive is initialized  as point to a single element. I have replaced the field of the structure with static massive, to make it quite work.
But the dynamic massive with correct size is needed. Correct size of massive must be evaluated.